### PR TITLE
Minor cleanup of `test_config.py`

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,26 +2,25 @@ from yacron import config
 
 
 def test_mergedicts():
-	assert dict(config.mergedicts({"a": 1}, {"b": 2})) == {"a": 1, "b": 2}
+    assert dict(config.mergedicts({"a": 1}, {"b": 2})) == {"a": 1, "b": 2}
 
 
 def test_mergedicts_nested():
-	assert dict(config.mergedicts(
-	    {"a": {'x': 1, 'y': 2, 'z': 3}},
-	    {'a': {'y': 10}, "b": 2})) == \
-		{"a": {'x': 1, 'y': 10, 'z': 3}, "b": 2}
+    assert (dict(config.mergedicts(
+        {"a": {'x': 1, 'y': 2, 'z': 3}},
+        {'a': {'y': 10}, "b": 2}
+    )) == {"a": {'x': 1, 'y': 10, 'z': 3}, "b": 2})
 
 
 def test_mergedicts_right_none():
-	assert dict(config.mergedicts(
-	    {"a": {'x': 1}},
-	    {"a": None, "b": 2})) == \
-		{"a": {'x': 1}, "b": 2}
+    assert (dict(config.mergedicts(
+        {"a": {'x': 1}},
+        {"a": None, "b": 2}
+    )) == {"a": {'x': 1}, "b": 2})
 
 
 def test_mergedicts_lists():
-	assert dict(config.mergedicts(
-	    {"env": [{'key': 'FOO'}]},
-	    {"env": [{'key': 'BAR'}]})) \
-		== \
-		{"env": [{'key': 'FOO'}, {'key': 'BAR'}]}
+    assert (dict(config.mergedicts(
+        {"env": [{'key': 'FOO'}]},
+        {"env": [{'key': 'BAR'}]}
+    )) == {"env": [{'key': 'FOO'}, {'key': 'BAR'}]})


### PR DESCRIPTION
* Replace tabs with spaces
    > [Spaces are the preferred indentation method.](https://pep8.org/#tabs-or-spaces)

* Use parentheses to get rid of backslashes for line continuation
    > [The preferred way of wrapping long lines is by using Python’s implied line continuation inside parentheses, brackets and braces. Long lines can be broken over multiple lines by wrapping expressions in parentheses. These should be used in preference to using a backslash for line continuation.](https://pep8.org/#maximum-line-length)
