### PR TITLE
refactor use of strictyaml to report label.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.rst') as readme_file:
 
 
 requirements = [
-    "strictyaml>=0.7",
+    "strictyaml>=0.7.2",
     "crontab",
     "aiohttp",
     "raven",

--- a/yacron/config.py
+++ b/yacron/config.py
@@ -95,8 +95,8 @@ _job_defaults_common = {
     Opt("saveLimit"): Int(),
     Opt("failsWhen"): Map({
         "producesStdout": Bool(),
-        "producesStderr": Bool(),
-        "nonzeroReturn": Bool(),
+        Opt("producesStderr"): Bool(),
+        Opt("nonzeroReturn"): Bool(),
     }),
     Opt("onFailure"): Map({
         Opt("retry"): Map({
@@ -203,14 +203,8 @@ def parse_config_file(path: str) -> List[JobConfig]:
 def parse_config_string(data: str, path: Optional[str] = None,
                         ) -> List[JobConfig]:
     try:
-        doc = strictyaml.load(data, CONFIG_SCHEMA).data
+        doc = strictyaml.load(data, CONFIG_SCHEMA, label=path).data
     except StrictYAMLError as ex:
-        if ex.context_mark is not None:
-            ex.context_mark.name = path
-        if ex.problem_mark is not None:
-            ex.problem_mark.name = path
-        raise ConfigError(str(ex))
-    except YAMLError as ex:
         raise ConfigError(str(ex))
 
     defaults = doc.get('defaults', {})

--- a/yacron/config.py
+++ b/yacron/config.py
@@ -70,11 +70,11 @@ DEFAULT_CONFIG = {
 
 
 _report_schema = Map({
-    "sentry": Map({
+    Opt("sentry"): Map({
         Opt("dsn"): Map({
-            Opt("value"): Str() | EmptyNone(),
-            Opt("fromFile"): Str() | EmptyNone(),
-            Opt("fromEnvVar"): Str() | EmptyNone(),
+            Opt("value"): EmptyNone() | Str(),
+            Opt("fromFile"): EmptyNone() | Str(),
+            Opt("fromEnvVar"): EmptyNone() | Str(),
         }),
     }),
     Opt("mail"): Map({
@@ -204,7 +204,7 @@ def parse_config_string(data: str, path: Optional[str] = None,
                         ) -> List[JobConfig]:
     try:
         doc = strictyaml.load(data, CONFIG_SCHEMA, label=path).data
-    except StrictYAMLError as ex:
+    except YAMLError as ex:
         raise ConfigError(str(ex))
 
     defaults = doc.get('defaults', {})


### PR DESCRIPTION
The latest version includes the fix https://github.com/crdoconnor/strictyaml/issues/26 mentioned in #4.

Full disclosure : there was another embarrassing bug whereby all keys were treated as optional in Map which is now also fixed. When I tried running 
https://github.com/gjcarneiro/yacron/blob/master/example/adhoc.yacron.d/test.yaml
it started failing because producesStderr and nonzeroReturn were not present on line 36. I attempted to fix this by making them optional.