### PR TITLE
Added Statsd metrics sending

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -242,6 +242,35 @@ Example:
             (exit code: {{exit_code}})
 
 
+Metrics
++++++++++
+
+Yacron has builtin support for writing job metrics to Statsd_:
+
+.. _Statsd: https://github.com/etsy/statsd
+
+.. code-block:: yaml
+
+    jobs:
+      - name: test01
+        command: echo "hello"
+        schedule: "* * * * *"
+        statsd:
+          host: my-statsd.exemple.com
+          port: 8125
+          prefix: my.cron.jobs.prefix.test01
+
+With this config Yacron will write the following metrics over UDP
+to the Statsd listening on ``my-statsd.exemple.com:8125``:
+
+.. code-block::
+
+  my.cron.jobs.prefix.test01.start:1|g  # this one is sent when the job starts
+  my.cron.jobs.prefix.test01.stop:1|g   # the rest are sent when the job stops
+  my.cron.jobs.prefix.test01.success:1|g
+  my.cron.jobs.prefix.test01.duration:3|ms|@0.1
+
+
 Handling failure
 ++++++++++++++++
 

--- a/yacron/config.py
+++ b/yacron/config.py
@@ -91,6 +91,7 @@ DEFAULT_CONFIG = {
     'environment': [],
     'executionTimeout': None,
     'killTimeout': 30,
+    'statsd': None,
 }
 
 
@@ -145,6 +146,11 @@ _job_defaults_common = {
     })),
     Opt("executionTimeout"): Float(),
     Opt("killTimeout"): Float(),
+    Opt("statsd"): Map({
+        'prefix': Str(),
+        'host': Str(),
+        'port': Int(),
+    }),
 }
 
 _job_schema_dict = dict(_job_defaults_common)
@@ -218,6 +224,7 @@ class JobConfig:
         self.environment = config.pop('environment')
         self.executionTimeout = config.pop('executionTimeout')
         self.killTimeout = config.pop('killTimeout')
+        self.statsd = config.pop('statsd')
 
 
 def parse_config_file(path: str) -> List[JobConfig]:

--- a/yacron/statsd.py
+++ b/yacron/statsd.py
@@ -1,4 +1,5 @@
 import logging
+import time
 import asyncio
 
 
@@ -15,7 +16,6 @@ class StatsdClientProtocol:
     def connection_made(self, transport):
         self.transport = transport
         self.transport.sendto(self.message.encode())
-        self.transport.close()
 
     def datagram_received(self, data, addr):
         pass
@@ -32,4 +32,42 @@ async def send_to_statsd(host, port, message):
     connect = loop.create_datagram_endpoint(
         lambda: StatsdClientProtocol(message, loop),
         remote_addr=(host, port))
-    await connect
+    transport, protocol = await connect
+    transport.close()
+
+
+class StatsdJobMetricWriter:
+
+    def __init__(self, host, port, prefix, job):
+        self.host = host
+        self.port = port
+        self.prefix = prefix
+        self.start_time = None
+        self.job = job
+
+    async def job_started(self) -> None:
+        self.start_time = time.perf_counter()
+        await send_to_statsd(
+            self.host,
+            self.port,
+            '{prefix}.start:1|g\n'.format(prefix=self.prefix)
+        )
+
+    async def job_stopped(self) -> None:
+        if self.start_time is None:
+            return
+        duration_seconds = time.perf_counter() - self.start_time
+        duration = int(round(duration_seconds * 1000))
+        await send_to_statsd(
+            self.host,
+            self.port,
+            (
+                '{prefix}.stop:1|g\n'
+                '{prefix}.success:{success}|g\n'
+                '{prefix}.duration:{duration}|ms|@0.1\n'
+            ).format(
+                prefix=self.prefix,
+                success=0 if self.job.failed else 1,
+                duration=duration,
+            ),
+        )

--- a/yacron/statsd.py
+++ b/yacron/statsd.py
@@ -1,0 +1,35 @@
+import logging
+import asyncio
+
+
+logger = logging.getLogger('statsd')
+
+
+class StatsdClientProtocol:
+
+    def __init__(self, message, loop):
+        self.message = message
+        self.loop = loop
+        self.transport = None
+
+    def connection_made(self, transport):
+        self.transport = transport
+        self.transport.sendto(self.message.encode())
+        self.transport.close()
+
+    def datagram_received(self, data, addr):
+        pass
+
+    def error_received(self, exc):
+        logger.error('UDP error received:', exc)
+
+    def connection_lost(self, exc):
+        pass
+
+
+async def send_to_statsd(host, port, message):
+    loop = asyncio.get_event_loop()
+    connect = loop.create_datagram_endpoint(
+        lambda: StatsdClientProtocol(message, loop),
+        remote_addr=(host, port))
+    await connect


### PR DESCRIPTION
Added the ability to send job related metrics to Statsd.
example config:
```yaml
jobs:
  - name: test
    command: echo "hello"
    schedule: "* * * * *"
    statsd:
      host: my-statsd.example.com
      port: 8125
      prefix: my.cron.test
```
With the config above Yacron will send these metrics to Statsd over UDP:

```
my.cron.test.start:1|g  #  this one is sent when the job starts
my.cron.test.stop:1|g  # this one and the ones below are sent when the job stops
my.cron.test.success:1|g
my.cron.test.duration:123|ms|@0.1
```