### PR TITLE
Add ability to run a job at yacron startup, like cron @reboot

### DIFF
--- a/yacron/config.py
+++ b/yacron/config.py
@@ -91,6 +91,7 @@ DEFAULT_CONFIG = {
     'environment': [],
     'executionTimeout': None,
     'killTimeout': 30,
+    'runOnStartup': False,
 }
 
 
@@ -145,6 +146,7 @@ _job_defaults_common = {
     })),
     Opt("executionTimeout"): Float(),
     Opt("killTimeout"): Float(),
+    Opt("runOnStartup"): Bool(),
 }
 
 _job_schema_dict = dict(_job_defaults_common)
@@ -218,6 +220,7 @@ class JobConfig:
         self.environment = config.pop('environment')
         self.executionTimeout = config.pop('executionTimeout')
         self.killTimeout = config.pop('killTimeout')
+        self.runOnStartup = config.pop('runOnStartup')
 
 
 def parse_config_file(path: str) -> List[JobConfig]:


### PR DESCRIPTION
I need to add tests and update the documentation, but before I did that I wanted to get some comments on it.

I'm using yacron to startup a few services and check they are alive inside a docker container, as well as run some actual scheduled tasks.

