### PR TITLE
add @reboot schedule, retry always and infinite retries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,10 +87,11 @@ configuration:
         schedule: "*/5 * * * *"
 
 
-The `schedule` option can be a string in the traditional crontab format, or can
-be an object with properties.  The following configuration runs a command every
-5 minutes, but only on the specific date 2017-07-19, and doesn't run it in any
-other date:
+The `schedule` option can be a string in the traditional crontab format
+(including @reboot, which will only run the job when yacron is initially
+executed), or can be an object with properties.  The following configuration
+runs a command every 5 minutes, but only on the specific date 2017-07-19, and
+doesn't run it in any other date:
 
 .. code-block:: yaml
 
@@ -258,6 +259,7 @@ You can instruct yacron how to determine if a job has failed or not via the
     producesStdout: false
     producesStderr: true
     nonzeroReturn: true
+    always: false
 
 producesStdout
     If true, any captured standard output causes yacron to consider the job
@@ -270,6 +272,10 @@ producesStderr
 nonzeroReturn
     If true, if the job process returns a code other than zero causes yacron
     to consider the job as failed.  This is true by default.
+
+always
+    If true, if the job process exits that causes yacron to consider the job as
+    failed.  This is false by default.
 
 It is possible to instruct yacron to retry failing cron jobs by adding a
 ``retry`` option inside ``onFailure``:
@@ -298,7 +304,10 @@ It is possible to instruct yacron to retry failing cron jobs by adding a
 
 The above settings tell yacron to retry the job up to 10 times, with the delay
 between retries defined by an exponential backoff process: initially 1 second,
-doubling for every retry up to a maximum of 30 seconds.
+doubling for every retry up to a maximum of 30 seconds. A value of -1 for
+maximumRetries will mean yacron will keep retrying forever, this is mostly
+useful with a schedfule of "@reboot" to restart a long running process when it
+has failed.
 
 If the cron job is expected to fail sometimes, you may wish to report only in
 the case the cron job ultimately fails after all retries and we give up on it.

--- a/yacron/config.py
+++ b/yacron/config.py
@@ -72,6 +72,7 @@ DEFAULT_CONFIG = {
         'producesStdout': False,
         'producesStderr': True,
         'nonzeroReturn': True,
+        'always': False,
     },
     'onFailure': {
         'retry': {
@@ -123,6 +124,7 @@ _job_defaults_common = {
         "producesStdout": Bool(),
         Opt("producesStderr"): Bool(),
         Opt("nonzeroReturn"): Bool(),
+        Opt("always"): Bool(),
     }),
     Opt("onFailure"): Map({
         Opt("retry"): Map({
@@ -193,7 +195,9 @@ class JobConfig:
         self.name = config['name']  # type: str
         self.command = config['command']  # type: Union[str, List[str]]
         self.schedule_unparsed = config.pop('schedule')
-        if isinstance(self.schedule_unparsed, str):
+        if isinstance(self.schedule_unparsed, str) and self.schedule_unparsed == "@reboot":
+            self.schedule = "@reboot"
+        elif isinstance(self.schedule_unparsed, str):
             self.schedule = CronTab(self.schedule_unparsed)  # type: CronTab
         elif isinstance(self.schedule_unparsed, dict):
             minute = self.schedule_unparsed.get("minute", "*")

--- a/yacron/cron.py
+++ b/yacron/cron.py
@@ -8,7 +8,7 @@ from typing import Any, Awaitable, Dict, List, Optional  # noqa
 from yacron.config import (JobConfig, parse_config, ConfigError,
                            parse_config_string)
 from yacron.job import RunningJob, JobRetryState
-
+from crontab import CronTab
 
 logger = logging.getLogger('yacron')
 WAKEUP_INTERVAL = datetime.timedelta(minutes=1)
@@ -58,6 +58,7 @@ class Cron:
         self._wait_for_running_jobs_task = \
             create_task(self._wait_for_running_jobs())
 
+        startUp=True
         while not self._stop_event.is_set():
             try:
                 self.update_config()
@@ -66,7 +67,8 @@ class Cron:
                              "any of the config.:\n%s", str(err))
             except Exception as exc:  # pragma: nocover
                 logger.exception("please report this as a bug (1)")
-            await self.spawn_jobs()
+            await self.spawn_jobs(startUp)
+            startUp=False
             sleep_interval = next_sleep_interval()
             logger.debug("Will sleep for %.1f seconds", sleep_interval)
             try:
@@ -91,15 +93,20 @@ class Cron:
         config = parse_config(self.config_arg)
         self.cron_jobs = OrderedDict((job.name, job) for job in config)
 
-    async def spawn_jobs(self) -> None:
+    async def spawn_jobs(self,startUp) -> None:
         now = get_now()
         for job in self.cron_jobs.values():
-            if job.schedule.test(now):
-                logger.debug("Job %s (%s) is scheduled for now",
+            if startUp and isinstance(job.schedule,str) and job.schedule == "@reboot":
+                logger.debug("Job %s (%s) is scheduled for startup (@reboot)",
                              job.name, job.schedule_unparsed)
                 await self.launch_scheduled_job(job)
             else:
-                logger.debug("Job %s (%s) not scheduled for now",
+                if isinstance(job.schedule,CronTab) and job.schedule.test(now):
+                    logger.debug("Job %s (%s) is scheduled for now",
+                             job.name, job.schedule_unparsed)
+                    await self.launch_scheduled_job(job)
+                else:
+                    logger.debug("Job %s (%s) not scheduled for now",
                              job.name, job.schedule_unparsed)
 
     async def launch_scheduled_job(self, job: JobConfig) -> None:
@@ -213,7 +220,7 @@ class Cron:
             else:
                 state.task.cancel()
         retry = job.config.onFailure['retry']
-        if state.count >= retry['maximumRetries']:
+        if state.count >= retry['maximumRetries'] and retry['maximumRetries']  != -1:
             await self.cancel_job_retries(job.config.name)
             await job.report_permanent_failure()
         else:

--- a/yacron/job.py
+++ b/yacron/job.py
@@ -52,13 +52,14 @@ class StreamReader:
                 return
             sys.stdout.write(prefix + line)
             sys.stdout.flush()
-            if len(self.save_top) < limit_top:
-                self.save_top.append(line)
-            else:
-                if len(self.save_bottom) == limit_bottom:
-                    del self.save_bottom[0]
-                    self.discarded_lines += 1
-                self.save_bottom.append(line)
+            if self.save_limit > 0:
+                if len(self.save_top) < limit_top:
+                    self.save_top.append(line)
+                else:
+                    if len(self.save_bottom) == limit_bottom:
+                        del self.save_bottom[0]
+                        self.discarded_lines += 1
+                    self.save_bottom.append(line)
 
     async def join(self) -> str:
         await self._reader
@@ -252,6 +253,8 @@ class RunningJob:
 
     @property
     def failed(self) -> bool:
+        if self.config.failsWhen['always']:
+            return True
         if self.config.failsWhen['nonzeroReturn'] and self.retcode != 0:
             return True
         if self.config.failsWhen['producesStdout'] and self.stdout:


### PR DESCRIPTION
Allow the cron syntax of @reboot to be used in the schedule line to mean a job should be started when yacron starts.

Allow a job to be marked as failed if it exits at all.

Allow -1 to be used for maximumRetries to mean infinite retries.

Let me know what you think and I'll take a look at adding tests once you're happy with the functoin.