### PR TITLE
configuration validation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 History
 =======
 
+0.9.0
+------------------
+* Added an option to just check if the yaml file is valid without running the scheduler.
+
 0.8.1 (2018-10-16)
 ------------------
 * Fix a bug handling ``@reboot`` in schedule (#22)

--- a/yacron/__main__.py
+++ b/yacron/__main__.py
@@ -13,6 +13,7 @@ def main_loop(loop):
     parser.add_argument('-c', "--config", default="/etc/yacron.d",
                         metavar="FILE-OR-DIR")
     parser.add_argument('-l', "--log-level", default="INFO")
+    parser.add_argument('-v', "--validate-config", default=False)
     args = parser.parse_args()
 
     logging.basicConfig(level=getattr(logging, args.log_level))
@@ -24,6 +25,10 @@ def main_loop(loop):
     except ConfigError as err:
         logger.error("Configuration error: %s", str(err))
         sys.exit(1)
+        
+    if args.validate_config == True:
+        logger.info("Configuration is valid.")
+        sys.exit(0)
 
     loop.add_signal_handler(signal.SIGINT, cron.signal_shutdown)
     loop.add_signal_handler(signal.SIGTERM, cron.signal_shutdown)


### PR DESCRIPTION
Added an option to just check if the yaml file is valid without running the scheduler.

Added boolean command line argument -v. If set to true, after Cron object is created with no errors then program exits with code 0

