### PR TITLE
Shell Reporter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -220,7 +220,7 @@ Reporting
 +++++++++
 
 Yacron has builtin support for reporting jobs failure (more on that below) by
-email and Sentry (additional reporting methods might be added in the future):
+email, Sentry and shell command (additional reporting methods might be added in the future):
 
 .. code-block:: yaml
 
@@ -331,6 +331,29 @@ Example:
             {{stderr}}
             (exit code: {{exit_code}})
 
+
+The shell reporter executes a user given shell command in the specified shell.
+It passes all environment variables from the python executable and specifies
+some additional ones to inform about the state of the job:
+* YACRON_FAIL_REASON (str)
+* YACRON_FAILED ("1" or "0")
+* YACRON_RETCODE (str)
+* YACRON_STDERR (str)
+* YACRON_STDOUT (str)
+
+A simple example configuration:
+
+.. code-block:: yaml
+
+  - name: test-01
+    command: echo "foobar" && exit 123
+    shell: /bin/bash
+    schedule: "* * * * *"
+    onFailure:
+      report:
+        shell:
+          shell: /bin/bash
+          command: echo "Error code $YACRON_RETCODE"
 
 Metrics
 +++++++++

--- a/yacron/config.py
+++ b/yacron/config.py
@@ -75,6 +75,10 @@ _REPORT_DEFAULTS = {
         "username": None,
         "password": {"value": None, "fromFile": None, "fromEnvVar": None},
     },
+    "shell" : {
+        "shell": "/bin/sh",
+        "command": None,
+    },
 }
 
 
@@ -146,6 +150,12 @@ _report_schema = Map(
                 ),
                 Opt("tls"): Bool(),
                 Opt("starttls"): Bool(),
+            }
+        ),
+        Opt("shell"): Map(
+            {
+                Opt("shell"): Str(),
+                "command": Str() | Seq(Str()),
             }
         ),
     }

--- a/yacron/job.py
+++ b/yacron/job.py
@@ -211,11 +211,11 @@ class ShellReporter:
         # pass the necessary information as env variables
         env = {
             **os.environ,
-            "fail_reason": job.fail_reason if job.fail_reason != None else "",
-            "failed": "1" if job.failed else "0",
-            "retcode": str(job.retcode),
-            "stderr": job.stderr if job.stderr != None else "",
-            "stdout": job.stdout if job.stdout != None else "",
+            "YACRON_FAIL_REASON": job.fail_reason if job.fail_reason is not None else "",
+            "YACRON_FAILED": "1" if job.failed else "0",
+            "YACRON_RETCODE": str(job.retcode),
+            "YACRON_STDERR": job.stderr if job.stderr is not None else "",
+            "YACRON_STDOUT": job.stdout if job.stdout is not None else "",
         }
 
         try:


### PR DESCRIPTION
### Description
I added the shell reporter as a new reporter implementation which simply executes a shell command on failure or success.

The motivation was to be able to send notifications to [Gotify](https://github.com/gotify) via a curl call. The implementation uses the same code that is used to execute the command of jobs. Additionally a small set of environment variables is added to the report command containing information about the state of the job.

### Example
```yml
jobs:
  - name: test-01
    command: echo "foobar" && exit 123
    shell: /bin/bash
    schedule: "* * * * *"
    onFailure:
      report:
        shell:
          command: echo "Error code $retcode"
```
The user can specify the command the same way that is used for the job itself. In the same spirit the shell can be chosen as well.

### Limitations
At the moment no unit test is provided. If required I can add one although I am unsure of how to properly test this (best idea so far is to write content to a file in the shell command being executed by the reporter).
Furthermore I haven't updated the documentation. Will do that in case the feature is generally liked.