### PR TITLE
Validate config parameter fix

### DIFF
--- a/yacron/__main__.py
+++ b/yacron/__main__.py
@@ -15,7 +15,7 @@ def main_loop(loop):
         "-c", "--config", default="/etc/yacron.d", metavar="FILE-OR-DIR"
     )
     parser.add_argument("-l", "--log-level", default="INFO")
-    parser.add_argument("-v", "--validate-config", default=False)
+    parser.add_argument("-v", "--validate-config", default=False, action="store_true")
     parser.add_argument("--version", default=False, action="store_true")
     args = parser.parse_args()
 
@@ -33,7 +33,7 @@ def main_loop(loop):
         logger.error("Configuration error: %s", str(err))
         sys.exit(1)
 
-    if args.validate_config is True:
+    if args.validate_config:
         logger.info("Configuration is valid.")
         sys.exit(0)
 


### PR DESCRIPTION
Hello there!

I've found an error in -v / --validate-config behaviour and this code should be able to fix that.

In particular, python, afaik, doesn't have any capability to cast input arguments to boolean (so even if you would set `--validate-config True` it would be string value, not a boolean), thus Line 36 condition will fail anyway.

Now it is possible to use as a normal option without passing additional argument (like `--version` ie).

If you may, please, consider reviewing this promptly, 'cause we're using Yacron in _kinda_ production environment and this type of validation is somewhat crucial for our CI/CD pipelines - our devs aren't careful enough to validate configuration on their own.

Thanks in advance.