### PR TITLE
Shell Reporter Argument Length

### DIFF
--- a/yacron/job.py
+++ b/yacron/job.py
@@ -246,8 +246,8 @@ class ShellReporter(Reporter):
         args_too_long = len(std_err_str) > max_length_arg or \
                         len(std_out_str) > max_length_arg or \
                         len(std_err_str) + len(std_out_str) > max_length_arg
-        std_err_str = std_err_str if not args_too_long else ""
-        std_out_str = std_out_str if not args_too_long else ""
+        std_err_str_safe = std_err_str if not args_too_long else std_err_str[:max_length_arg]
+        std_out_str_safe = std_out_str if not args_too_long else std_out_str[:max_length_arg]
 
         env = {
             **os.environ,
@@ -263,8 +263,10 @@ class ShellReporter(Reporter):
             "YACRON_JOB_SCHEDULE": job.config.schedule_unparsed,
             "YACRON_FAILED": "1" if job.failed else "0",
             "YACRON_RETCODE": str(job.retcode),
-            "YACRON_STDERR": std_err_str,
-            "YACRON_STDOUT": std_out_str,
+            "YACRON_STDERR": std_err_str_safe,
+            "YACRON_STDOUT": std_out_str_safe,
+            "YACRON_STDERR_TRUNCATED": len(std_err_str_safe) != len(std_err_str),
+            "YACRON_STDOUT_TRUNCATED": len(std_out_str_safe) != len(std_out_str),
         }
 
         logger.debug("Executing shell report cmd: %s", cmd)

--- a/yacron/job.py
+++ b/yacron/job.py
@@ -243,7 +243,9 @@ class ShellReporter(Reporter):
         std_out_str = job.stdout if job.stdout is not None else ""
         # this is an arbitrary safe lower limit
         max_length_arg = 1024 * 16
-        args_too_long = len(std_err_str) > max_length_arg or len(std_out_str) > max_length_arg
+        args_too_long = len(std_err_str) > max_length_arg or \
+                        len(std_out_str) > max_length_arg or \
+                        len(std_err_str) + len(std_out_str) > max_length_arg
         std_err_str = std_err_str if not args_too_long else ""
         std_out_str = std_out_str if not args_too_long else ""
 


### PR DESCRIPTION
I ran into a problem when the stderr or stdout strings became very large because the OS has limits on their length and the shell then throws the following error:
`ERROR:yacron:Problem reporting job backup failure: [Errno 7] Argument list too long: '/bin/sh'
Traceback (most recent call last):
File "/usr/local/lib/python3.8/dist-packages/yacron/job.py", line 251, in report`

The easy solution is of course to have a hard cap on the length of these strings, over which they don't get passed. The question then becomes what this limit is. I found some information regarding Linux [here](https://stackoverflow.com/a/29802900/1715849). But since this is OS specific and potentially configurable I decided to go with a safe lower limit instead of trying to determine the correct limit at rune time.