### PR TITLE
GitHub Action to run the tox tests

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,36 @@
+name: tox
+on: [push, pull_request]
+jobs:
+  tox-flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e flake8
+
+  tox-mypy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e mypy
+
+  tox:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        python: ['3.7', '3.8', '3.9', '3.10']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,17 @@
 [tox]
-envlist = py37, py38, py39, flake8, mypy
+envlist = py37, py38, py39, py310, flake8, mypy
 
 [travis]
 python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv:flake8]
 basepython=python3
 deps=flake8
-commands=flake8 yacron tests
+commands=flake8 --max-line-length=88 yacron tests
 
 [testenv:mypy]
 basepython=python3


### PR DESCRIPTION
Because **Travis CI** is on an [extended vacation](https://travis-ci.org/github/gjcarneiro/yacron/builds).

Test results: https://github.com/cclauss/yacron/actions

The failing test seems to be sporadic.