### PR TITLE
Add config value for SMTP(validate_certs=False)

### DIFF
--- a/yacron/config.py
+++ b/yacron/config.py
@@ -73,6 +73,7 @@ _REPORT_DEFAULTS = {
         "smtpPort": 25,
         "tls": False,
         "starttls": False,
+        "validate_certs": False,
         "html": False,
         "subject": DEFAULT_SUBJECT_TEMPLATE,
         "body": DEFAULT_BODY_TEMPLATE,
@@ -159,6 +160,7 @@ _report_schema = Map(
                 ),
                 Opt("tls"): Bool(),
                 Opt("starttls"): Bool(),
+                Opt("validate_certs"): Bool(),
                 Opt("html"): Bool(),
             }
         ),

--- a/yacron/job.py
+++ b/yacron/job.py
@@ -207,7 +207,10 @@ class MailReporter(Reporter):
         else:
             message.set_content(body)
         smtp = aiosmtplib.SMTP(
-            hostname=smtp_host, port=smtp_port, use_tls=mail["tls"]
+            hostname=smtp_host,
+            port=smtp_port,
+            use_tls=mail["tls"],
+            validate_certs=mail["validate_certs"],
         )
         await smtp.connect()
         if mail["starttls"]:


### PR DESCRIPTION
Needed if you have SMTP server with self-signed certificate

(In these examples, the smtp server is running in another container on the same pod, with self-signed certs generated every build or every restart.)

It's not possible to connect with `tls=False` (not really sure why):

```py
>>> import aiosmtplib
>>> import asyncio

>>> smtp = aiosmtplib.SMTP(hostname="localhost", port=25, use_tls=False)
>>> asyncio.run(smtp.connect())
Traceback (most recent call last):
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1131)
```

Passing `validate_certs=False` appears to work:

```py
>>> smtp = aiosmtplib.SMTP(hostname="localhost", port=25, use_tls=False, validate_certs=False)
>>> asyncio.run(smtp.connect())
(220, cron2-84ddcdb9dd-7vvrd ESMTP Exim 4.93 Ubuntu Tue, 24 Jan 2023 19:28:24 +0000)
```

It would be useful to pass this config variable to the SMTP() constructor