### PR TITLE
Customizable logging configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -764,3 +764,37 @@ validating the configuration.
         command: echo "foobar"
         shell: /bin/bash
         schedule: "* * * * *"
+
+
+Custom logging
+++++++++++++++
+
+It's possible to provide a custom logging configuration. To do it, prepare
+an appropriate configuration in a YAML file. Then pass it to yacron to using
+``--log-config`` argument.
+
+
+.. code-block:: yaml
+
+    # In the format of:
+    # https://docs.python.org/3/library/logging.config.html#dictionary-schema-details
+
+    version: 1
+
+    disable_existing_loggers: False
+
+    formatters:
+      simple:
+        format: '%(asctime)s [%(processName)s/%(threadName)s] %(levelname)s (%(name)s): %(message)s'
+
+    handlers:
+      console:
+        class: logging.StreamHandler
+        level: DEBUG
+        formatter: simple
+        stream: ext://sys.stdout
+
+    root:
+      level: INFO
+      handlers: [console]
+

--- a/yacron/__main__.py
+++ b/yacron/__main__.py
@@ -2,9 +2,12 @@ import argparse
 import asyncio
 import asyncio.subprocess
 import logging
+import logging.config
 import signal
 import sys
 import os
+
+import ruamel.yaml
 
 from yacron.cron import Cron, ConfigError
 import yacron.version
@@ -23,18 +26,32 @@ def main_loop(loop):
     )
     parser.add_argument("-l", "--log-level", default="INFO")
     parser.add_argument(
+        "--log-config",
+        required=False,
+        help="logging configuration file in format as of: "
+             "https://docs.python.org/3/library/logging.config.html#dictionary-schema-details"  # noqa: E501
+    )
+    parser.add_argument(
         "-v", "--validate-config", default=False, action="store_true"
     )
     parser.add_argument("--version", default=False, action="store_true")
     args = parser.parse_args()
 
     logging.basicConfig(level=getattr(logging, args.log_level))
-    # logging.getLogger("asyncio").setLevel(logging.WARNING)
     logger = logging.getLogger("yacron")
 
     if args.version:
         print(yacron.version.version)
         sys.exit(0)
+
+    if args.log_config:
+        with open(args.log_config, "rt", encoding="utf-8") as stream:
+            try:
+                log_config = ruamel.yaml.safe_load(stream)
+                logging.config.dictConfig(log_config)
+            except ruamel.yaml.YAMLError as err:
+                print("logging configuration error: " + str(err), file=sys.stderr)
+                sys.exit(1)
 
     if args.config == CONFIG_DEFAULT and not os.path.exists(args.config):
         print(


### PR DESCRIPTION
Hi there!

I've added an option to customize logs produced by yacron. I've also wrote a note about it in README.

Motivation for the change was to find out when tasks has failed. I'm aware of the sentry integration though sometimes much simpler text file logs is enough.